### PR TITLE
Disable MEDIA_CONFERENCE_ID validation, api now also supports acronym

### DIFF
--- a/hls-relive/make-index.pl
+++ b/hls-relive/make-index.pl
@@ -51,8 +51,8 @@ while(my $name = readdir $dh) {
 
 	my $project_config = Relive::Config::read_config($config_path);
 	my $media_id = $project_config->{MEDIA_CONFERENCE_ID};
-	if (defined $media_id and $media_id =~ /[0-9]+/) {
-		$project->{media_conference_id} = $project_config->{MEDIA_CONFERENCE_ID} + 0;
+	if (defined $media_id and $media_id ne "") {
+		$project->{media_conference_id} = $project_config->{MEDIA_CONFERENCE_ID};
 	}
 
 	push @$projects, $project;


### PR DESCRIPTION
Since PR https://github.com/voc/voctoweb/pull/269 the voctoweb public API also supports conference lookup via acronym, additional to voctoweb's local conference id. This documented with https://github.com/voc/voctoweb/commit/f4834b00244465f7057187198b615986ed28024f